### PR TITLE
增加对url中带有多级目录的支持

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -87,7 +87,7 @@ func UrlFormat (Url string ) string {
 	var u *url.URL
 	if strings.HasPrefix(Url,"http") || strings.HasPrefix(Url,"https") {
 		u, _ = url.Parse(Url)
-		return fmt.Sprintf("%s://%s",u.Scheme,u.Host)
+		return fmt.Sprintf("%s://%s%s", u.Scheme, u.Host, strings.TrimRight(u.Path, "/"))
 	}else{
 		u,_ = url.Parse("//"+Url)
 		u.Scheme = "http"


### PR DESCRIPTION
修复在碰到默认存在一级目录，二级目录的url时，无法对路径进行拼接

当nacos应用实际部署在二级或者三级子目录
http://test.git.com/axy/nacos/#/login
http://test.git.com/axy/drwa/nacos/#/login

使用工具命令：
nacosleak.exe -t http://test.git.com/axy/或者nacosleak.exe -t http://test.git.com/axy
此时程序实际发送的请求是http://test.git.com/nacos/v1/auth/users/login，造成了直接忽略了目录路径，无法访问到实际的Nacos应用
